### PR TITLE
Make the size_t -> usize conversion explicit [fixes compilation]

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -20,6 +20,7 @@ fn main() {
         .whitelist_var("HYDRO_.*")
         .whitelist_var("hydro_.*")
         .whitelist_var("randombytes_.*")
+        .size_t_is_usize(true)
         .derive_copy(true)
         .derive_debug(true)
         .derive_default(true)


### PR DESCRIPTION
Hey! I was attempting to compile [hyper-sse](https://github.com/klemens/hyper-sse) just now (a crate that depends on your libhydrogen wrapper) and unfortunately this sys crate failed to compile with a bunch of type errors. I poked around and discovered that the implicit size_t to usize conversion that bindgen used to do was [removed](https://github.com/rust-lang/rust-bindgen/pull/1688) and subsequently replaced with an [explicit opt-in flag](https://github.com/rust-lang/rust-bindgen/pull/1720). Setting the flag does indeed resolve the issue, so the one-line change in this PR fixes everything!