### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ edition = "2018"
 build = "build.rs"
 
 [build-dependencies]
-bindgen = "0.60"
+bindgen = "0.63"
 cc = "1.0"


### PR DESCRIPTION
This updates `libhydrogen-sys` to use the latest version of `libhydrogen` upstream, and also updates bindgen to remove the dependency on `clap`.